### PR TITLE
[Chore] Add Codecov token to the test job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,6 @@ jobs:
         with:
           files: ./coverage/lcov.info
           flags: unittests # optional
-          token: $ # not required for public repos
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
           verbose: true


### PR DESCRIPTION
https://github.com/nimblehq/ic-flutter-avishek/issues/1

## What happened 👀

Contrary to the comment in the `test.yml` workflow file, the Codecov token is needed for private repos too. Therefore, add it to the job to show the Codecov report.

## Insight 📝

Added the token as instructed on [this](https://app.codecov.io/gh/nimblehq/ic-flutter-avishek/new) page.

## Proof Of Work 📹

See the comment left by Codecov below.