### PR TITLE
[#41] Set up navigation

### DIFF
--- a/integration_test/login_screen_test.dart
+++ b/integration_test/login_screen_test.dart
@@ -1,3 +1,6 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_survey/main.dart';
+import 'package:flutter_survey/ui/home/home_screen.dart';
 import 'package:flutter_survey/ui/login/login_screen.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -61,7 +64,14 @@ void main() {
         "When logging with valid email and password, it shows the success message",
         (WidgetTester tester) async {
       FakeData.addSuccessResponse(loginKey, loginJson);
-      await tester.pumpWidget(TestUtil.prepareTestApp(const LoginScreen()));
+      await tester.pumpWidget(
+        TestUtil.prepareTestApp(
+          const LoginScreen(),
+          routes: <String, WidgetBuilder>{
+            routePathHomeScreen: (BuildContext context) => const HomeScreen()
+          },
+        ),
+      );
 
       await tester.pumpAndSettle();
       await tester.enterText(tfEmail, 'test@abc.com');
@@ -69,7 +79,7 @@ void main() {
       await tester.tap(btLogin);
 
       await tester.pumpAndSettle();
-      expect(find.text('Logged in successfully!'), findsOneWidget);
+      expect(find.byType(HomeScreen), findsOneWidget);
     });
   });
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_survey/di/di.dart';
 import 'package:flutter_survey/theme/app_theme.dart';
 import 'package:flutter_survey/ui/home/home_screen.dart';
+import 'package:flutter_survey/ui/login/login_screen.dart';
 import 'package:go_router/go_router.dart';
 
 void main() async {
@@ -16,7 +17,7 @@ void main() async {
 }
 
 const routePathRootScreen = '/';
-const routePathSecondScreen = 'second';
+const routePathHomeScreen = 'home';
 
 class MyApp extends StatelessWidget {
   MyApp({Key? key}) : super(key: key);
@@ -26,12 +27,12 @@ class MyApp extends StatelessWidget {
       GoRoute(
         path: routePathRootScreen,
         builder: (BuildContext context, GoRouterState state) =>
-            const HomeScreen(),
+            const LoginScreen(),
         routes: [
           GoRoute(
-            path: routePathSecondScreen,
+            path: routePathHomeScreen,
             builder: (BuildContext context, GoRouterState state) =>
-                const SecondScreen(),
+                const HomeScreen(),
           ),
         ],
       ),
@@ -48,21 +49,6 @@ class MyApp extends StatelessWidget {
       routeInformationProvider: _router.routeInformationProvider,
       routeInformationParser: _router.routeInformationParser,
       routerDelegate: _router.routerDelegate,
-    );
-  }
-}
-
-class SecondScreen extends StatelessWidget {
-  const SecondScreen({
-    Key? key,
-  }) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text("Second Screen"),
-      ),
     );
   }
 }

--- a/lib/ui/login/login_screen.dart
+++ b/lib/ui/login/login_screen.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_survey/main.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../di/di.dart';
 import '../../gen/assets.gen.dart';
+import '../../usecases/is_logged_in_use_case.dart';
 import '../../usecases/login_use_case.dart';
 import '../widget/dimmed_image_background.dart';
 import '../widget/loading_indicator.dart';
@@ -18,7 +21,10 @@ const _loginFormRevealDuration = Duration(milliseconds: 700);
 
 final loginViewModelProvider =
     StateNotifierProvider.autoDispose<LoginViewModel, LoginState>((ref) {
-  return LoginViewModel(getIt.get<LoginUseCase>());
+  return LoginViewModel(
+    getIt.get<IsLoggedInUseCase>(),
+    getIt.get<LoginUseCase>(),
+  );
 });
 
 final _shouldAnimateLogoPositionProvider =
@@ -82,13 +88,12 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
           );
         },
         success: () {
-          // TODO: navigate to home
-          ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(content: Text("Logged in successfully!")));
+          context.replace('/$routePathHomeScreen');
         },
         orElse: () {},
       );
     });
+    ref.read(loginViewModelProvider.notifier).checkIfLoggedIn();
     return _buildLoginScreen();
   }
 

--- a/lib/ui/login/login_state.dart
+++ b/lib/ui/login/login_state.dart
@@ -11,4 +11,6 @@ class LoginState with _$LoginState {
   const factory LoginState.error(String? error) = _Error;
 
   const factory LoginState.success() = _Success;
+
+  const factory LoginState.loggedOut() = _LoggedOut;
 }

--- a/lib/ui/login/login_view_model.dart
+++ b/lib/ui/login/login_view_model.dart
@@ -1,5 +1,6 @@
 import 'package:email_validator/email_validator.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_survey/usecases/is_logged_in_use_case.dart';
 
 import '../../usecases/base/base_use_case.dart';
 import '../../usecases/login_use_case.dart';
@@ -8,9 +9,25 @@ import 'login_state.dart';
 const _minPasswordLength = 6;
 
 class LoginViewModel extends StateNotifier<LoginState> {
+  final IsLoggedInUseCase _isLoggedInUseCase;
   final LoginUseCase _loginUseCase;
 
-  LoginViewModel(this._loginUseCase) : super(const LoginState.init());
+  LoginViewModel(
+    this._isLoggedInUseCase,
+    this._loginUseCase,
+  ) : super(const LoginState.init());
+
+  void checkIfLoggedIn() async {
+    final result = await _isLoggedInUseCase.call();
+    if (result is Success<bool>) {
+      var isLoggedIn = result.value;
+      state = isLoggedIn
+          ? const LoginState.success()
+          : const LoginState.loggedOut();
+    } else {
+      _handleError(result as Failed);
+    }
+  }
 
   Future<void> logIn(String email, String password) async {
     state = const LoginState.loading();

--- a/lib/usecases/base/use_case_result.dart
+++ b/lib/usecases/base/use_case_result.dart
@@ -22,6 +22,9 @@ class Failed<T> extends Result<T> {
   Failed(this.exception) : super._();
 
   String? getErrorMessage() {
+    if (exception.actualException is! NetworkExceptions) {
+      return exception.actualException.message;
+    }
     return NetworkExceptions.getErrorMessage(exception.actualException);
   }
 }

--- a/lib/usecases/is_logged_in_use_case.dart
+++ b/lib/usecases/is_logged_in_use_case.dart
@@ -1,0 +1,19 @@
+import 'package:injectable/injectable.dart';
+
+import '../local/local_storage.dart';
+import 'base/base_use_case.dart';
+
+@lazySingleton
+class IsLoggedInUseCase extends NoParamsUseCase<bool> {
+  final LocalStorage _localStorage;
+
+  const IsLoggedInUseCase(this._localStorage);
+
+  @override
+  Future<Result<bool>> call() {
+    return _localStorage.isLoggedIn
+        .then((isLoggedIn) =>
+            Success(isLoggedIn) as Result<bool>) // ignore: unnecessary_cast
+        .onError<Exception>((err, stackTrace) => Failed(UseCaseException(err)));
+  }
+}

--- a/test/mocks/generate_mocks.dart
+++ b/test/mocks/generate_mocks.dart
@@ -5,6 +5,7 @@ import 'package:flutter_survey/api/authentication_service.dart';
 import 'package:flutter_survey/api/repository/authentication_repository.dart';
 import 'package:flutter_survey/local/local_storage.dart';
 import 'package:flutter_survey/usecases/base/base_use_case.dart';
+import 'package:flutter_survey/usecases/is_logged_in_use_case.dart';
 import 'package:flutter_survey/usecases/login_use_case.dart';
 import 'package:mockito/annotations.dart';
 
@@ -15,6 +16,7 @@ import 'package:mockito/annotations.dart';
   LocalStorage,
   FlutterSecureStorage,
   AuthenticationRepository,
+  IsLoggedInUseCase,
   LoginUseCase,
   UseCaseException
 ])

--- a/test/ui/login_view_model_test.dart
+++ b/test/ui/login_view_model_test.dart
@@ -11,15 +11,17 @@ import '../mocks/generate_mocks.mocks.dart';
 
 void main() {
   group('LoginViewModelTest', () {
+    late MockIsLoggedInUseCase mockIsLoggedInUseCase;
     late MockLoginUseCase mockLoginUseCase;
     late ProviderContainer container;
 
     setUp(() {
+      mockIsLoggedInUseCase = MockIsLoggedInUseCase();
       mockLoginUseCase = MockLoginUseCase();
       container = ProviderContainer(
         overrides: [
-          loginViewModelProvider
-              .overrideWithValue(LoginViewModel(mockLoginUseCase)),
+          loginViewModelProvider.overrideWithValue(
+              LoginViewModel(mockIsLoggedInUseCase, mockLoginUseCase)),
         ],
       );
       addTearDown(container.dispose);
@@ -28,6 +30,46 @@ void main() {
     test('When initializing, it initializes with Init', () {
       expect(container.read(loginViewModelProvider), const LoginState.init());
     });
+
+    test(
+        'When checking for logged in status and user is logged in, it emits values accordingly',
+        () {
+      when(mockIsLoggedInUseCase.call()).thenAnswer((_) async => Success(true));
+      final stateStream =
+          container.read(loginViewModelProvider.notifier).stream;
+
+      expect(stateStream, emitsInOrder([const LoginState.success()]));
+      container.read(loginViewModelProvider.notifier).checkIfLoggedIn();
+    });
+
+    test(
+        'When checking for logged in status and user is NOT logged in, it emits values accordingly',
+        () {
+      when(mockIsLoggedInUseCase.call())
+          .thenAnswer((_) async => Success(false));
+      final stateStream =
+          container.read(loginViewModelProvider.notifier).stream;
+
+      expect(stateStream, emitsInOrder([const LoginState.loggedOut()]));
+      container.read(loginViewModelProvider.notifier).checkIfLoggedIn();
+    });
+
+    test(
+      'When checking for logged in status runs into an error, it emits values accordingly',
+      () {
+        const mockErrorMessage = "errorMessage";
+        when(mockIsLoggedInUseCase.call()).thenAnswer(
+            (_) async => Failed(UseCaseException(Exception(mockErrorMessage))));
+        final stateStream =
+            container.read(loginViewModelProvider.notifier).stream;
+
+        expect(
+          stateStream,
+          emitsInOrder([const LoginState.error(mockErrorMessage)]),
+        );
+        container.read(loginViewModelProvider.notifier).checkIfLoggedIn();
+      },
+    );
 
     test('When logging in successfully, it returns Success', () {
       when(mockLoginUseCase.call(any)).thenAnswer((_) async => Success(null));

--- a/test/usecase/is_logged_in_use_case_test.dart
+++ b/test/usecase/is_logged_in_use_case_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_survey/usecases/base/base_use_case.dart';
+import 'package:flutter_survey/usecases/is_logged_in_use_case.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import '../mocks/generate_mocks.mocks.dart';
+
+void main() {
+  group("IsLoggedInUseCase", () {
+    final MockLocalStorage mockLocalStorage = MockLocalStorage();
+
+    late IsLoggedInUseCase isLoggedInUseCase;
+
+    setUp(() => {isLoggedInUseCase = IsLoggedInUseCase(mockLocalStorage)});
+
+    test("When calling the use case and user is logged in, it returns true",
+        () async {
+      var expectedResult = true;
+      when(
+        mockLocalStorage.isLoggedIn,
+      ).thenAnswer((_) async => expectedResult);
+
+      final result = await isLoggedInUseCase.call();
+
+      expect((result as Success).value, expectedResult);
+    });
+
+    test(
+        "When calling the use case and user is NOT logged in, it returns false",
+        () async {
+      var expectedResult = false;
+      when(
+        mockLocalStorage.isLoggedIn,
+      ).thenAnswer((_) async => expectedResult);
+
+      final result = await isLoggedInUseCase.call();
+
+      expect((result as Success).value, expectedResult);
+    });
+
+    test("When calling the use case unsuccessfully, it returns Failed",
+        () async {
+      when(
+        mockLocalStorage.isLoggedIn,
+      ).thenAnswer((_) => Future.error(Exception()));
+
+      final result = await isLoggedInUseCase.call();
+
+      expect(result, isA<Failed>());
+    });
+  });
+}


### PR DESCRIPTION
https://github.com/nimblehq/ic-flutter-avishek/issues/41

## What happened 👀

- Logged in users will be navigated to the Home screen (implemented in https://github.com/nimblehq/ic-flutter-avishek/issues/10 .
- Logged out users will be taken to the Login screen and upon successful login, take them to Home.

## Insight 📝

- Kept the existing implementation of `go_router` for navigation and modified the routes.
- Removed `SecondScreen`.

## Proof Of Work 📹

### Android

https://github.com/nimblehq/ic-flutter-avishek/assets/8093908/178d9493-0989-4a34-984e-8487fbfffcc4

### iOS

https://github.com/nimblehq/ic-flutter-avishek/assets/8093908/55419c56-b624-491b-8c73-755602c0d7c2

