### PR TITLE
[Chore] Remove the triggers from the iOS deployment workflows temporarily

### DIFF
--- a/.github/workflows/ios_deploy_staging_to_firebase.yml
+++ b/.github/workflows/ios_deploy_staging_to_firebase.yml
@@ -1,9 +1,10 @@
 name: ios-deploy-to-staging
-on:
-  # Trigger the workflow on push action
-  push:
-    branches:
-      - develop
+#Uncomment the trigger once the iOS deployment is set up.
+#on:
+#  # Trigger the workflow on push action
+#  push:
+#    branches:
+#      - develop
 
 jobs:
   build_and_upload_staging_app_to_firebase:

--- a/.github/workflows/ios_deploy_to_app_store.yml
+++ b/.github/workflows/ios_deploy_to_app_store.yml
@@ -1,9 +1,10 @@
 name: ios-deploy-to-app-store
-on:
-  # Trigger the workflow on push action
-  push:
-    branches:
-      - develop
+#Uncomment the trigger once the iOS deployment is set up.
+#on:
+#  # Trigger the workflow on push action
+#  push:
+#    branches:
+#      - develop
 
 jobs:
   build_and_upload_to_app_store:

--- a/.github/workflows/ios_deploy_to_testflight.yml
+++ b/.github/workflows/ios_deploy_to_testflight.yml
@@ -1,9 +1,10 @@
 name: ios-deploy-to-testflight
-on:
-  # Trigger the workflow on push action
-  push:
-    branches:
-      - develop
+#Uncomment the trigger once the iOS deployment is set up.
+#on:
+#  # Trigger the workflow on push action
+#  push:
+#    branches:
+#      - develop
 
 jobs:
   build_and_upload_to_testflight:


### PR DESCRIPTION
## What happened 👀

The deployment of the iOS app is not configured yet. Since this is a low-priority task, it'll be set up _after_ all the essential parts of the app are built.

## Insight 📝

Removed the triggers so that the workflows will not run.

## Proof Of Work 📹

N/A