### PR TITLE
[49] [50] [Backend] [Integrate] Cache surveys

### DIFF
--- a/integration_test/utils/test_util.dart
+++ b/integration_test/utils/test_util.dart
@@ -4,6 +4,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_survey/api/authentication_service.dart';
 import 'package:flutter_survey/di/di.dart';
+import 'package:flutter_survey/local/hive.dart';
 import 'package:flutter_survey/main.dart';
 import 'package:flutter_survey/theme/app_theme.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -61,6 +62,7 @@ class TestUtil {
       'CLIENT_SECRET': 'CLIENT_SECRET',
     });
 
+    await initHive();
     await configureInjection();
 
     getIt.allowReassignment = true;

--- a/lib/api/repository/survey_repository.dart
+++ b/lib/api/repository/survey_repository.dart
@@ -1,21 +1,52 @@
+import 'dart:async';
+
 import 'package:injectable/injectable.dart';
 
+import '../../local/local_storage.dart';
 import '../../model/survey.dart';
 import '../exception/network_exceptions.dart';
 import '../survey_service.dart';
 
 abstract class SurveyRepository {
-  Future<List<Survey>> getSurveys(int pageNumber, int pageSize);
+  Stream<List<Survey>> getSurveys(
+    int pageNumber,
+    int pageSize,
+    bool shouldRefresh,
+  );
 }
 
 @LazySingleton(as: SurveyRepository)
 class SurveyRepositoryImpl extends SurveyRepository {
   final SurveyService _surveyService;
+  final LocalStorage _localStorage;
 
-  SurveyRepositoryImpl(this._surveyService);
+  final _surveyStreamController = StreamController<List<Survey>>.broadcast();
+
+  SurveyRepositoryImpl(this._surveyService, this._localStorage);
 
   @override
-  Future<List<Survey>> getSurveys(int pageNumber, int pageSize) async {
+  Stream<List<Survey>> getSurveys(
+    int pageNumber,
+    int pageSize,
+    bool shouldRefresh,
+  ) {
+    if (shouldRefresh) {
+      _localStorage.clearCachedSurveys();
+    } else if (pageNumber == 1) {
+      _getCachedSurveys();
+    }
+    _getRemoteSurveys(
+      pageNumber,
+      pageSize,
+    );
+
+    return _surveyStreamController.stream;
+  }
+
+  Future<void> _getRemoteSurveys(
+    int pageNumber,
+    int pageSize,
+  ) async {
     try {
       final response = await _surveyService.getSurveys(
         pageNumber,
@@ -23,9 +54,25 @@ class SurveyRepositoryImpl extends SurveyRepository {
       );
       final surveys =
           response.data.map((e) => Survey.fromSurveyResponse(e)).toList();
-      return surveys;
+      _cacheSurveys(pageNumber, surveys);
+      _surveyStreamController.sink.add(surveys);
     } catch (exception) {
-      throw NetworkExceptions.fromDioException(exception);
+      _surveyStreamController.sink
+          .addError(NetworkExceptions.fromDioException(exception));
     }
+  }
+
+  Future<void> _getCachedSurveys() async {
+    var surveys = await _localStorage.surveys;
+    if (surveys.isNotEmpty) {
+      _surveyStreamController.sink.add(surveys);
+    }
+  }
+
+  void _cacheSurveys(int pageNumber, List<Survey> surveys) {
+    if (pageNumber == 1) {
+      _localStorage.clearCachedSurveys();
+    }
+    _localStorage.cacheSurveys(surveys);
   }
 }

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -1,0 +1,3 @@
+class HiveConstants {
+  static const String surveyBox = 'surveyBox';
+}

--- a/lib/di/module/storage_module.dart
+++ b/lib/di/module/storage_module.dart
@@ -1,10 +1,18 @@
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:hive/hive.dart';
 import 'package:injectable/injectable.dart';
 
+import '../../constants.dart';
+
 @module
-abstract class LocalModule {
+abstract class StorageModule {
   @singleton
   @preResolve
   Future<FlutterSecureStorage> get secureStorage async =>
       const FlutterSecureStorage();
+
+  @Named(HiveConstants.surveyBox)
+  @singleton
+  @preResolve
+  Future<Box> get surveyBox => Hive.openBox(HiveConstants.surveyBox);
 }

--- a/lib/local/hive.dart
+++ b/lib/local/hive.dart
@@ -1,0 +1,10 @@
+import 'package:hive/hive.dart';
+import 'package:path_provider/path_provider.dart' as path_provider;
+
+import '../model/survey.dart';
+
+Future<void> initHive() async {
+  final dbDir = await path_provider.getApplicationDocumentsDirectory();
+  Hive.init(dbDir.path);
+  Hive.registerAdapter(SurveyAdapter());
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,9 +8,12 @@ import 'package:flutter_survey/ui/home/home_screen.dart';
 import 'package:flutter_survey/ui/login/login_screen.dart';
 import 'package:go_router/go_router.dart';
 
+import 'local/hive.dart';
+
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await FlutterConfig.loadEnvVariables();
+  await initHive();
   await configureInjection();
 
   runApp(ProviderScope(child: MyApp()));

--- a/lib/model/survey.dart
+++ b/lib/model/survey.dart
@@ -1,10 +1,18 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_survey/model/response/survey_response.dart';
+import 'package:hive/hive.dart';
 
+part 'survey.g.dart';
+
+@HiveType(typeId: 0)
 class Survey extends Equatable {
+  @HiveField(0)
   final String id;
+  @HiveField(1)
   final String title;
+  @HiveField(2)
   final String description;
+  @HiveField(3)
   final String coverImageUrl;
 
   const Survey({

--- a/lib/usecases/base/base_use_case.dart
+++ b/lib/usecases/base/base_use_case.dart
@@ -17,3 +17,9 @@ abstract class NoParamsUseCase<T> extends BaseUseCase<Result<T>> {
 
   Future<Result<T>> call();
 }
+
+abstract class StreamUseCase<T, P> extends BaseUseCase<Result<T>> {
+  const StreamUseCase() : super();
+
+  Stream<Result<T>> call(P params);
+}

--- a/lib/usecases/get_surveys_use_case.dart
+++ b/lib/usecases/get_surveys_use_case.dart
@@ -1,5 +1,5 @@
-import 'package:flutter_survey/api/exception/network_exceptions.dart';
 import 'package:injectable/injectable.dart';
+import 'package:rxdart/rxdart.dart';
 
 import '../api/repository/survey_repository.dart';
 import '../model/survey.dart';
@@ -8,26 +8,31 @@ import 'base/base_use_case.dart';
 class GetSurveysInput {
   final int pageNumber;
   final int pageSize;
+  final bool shouldRefresh;
 
   GetSurveysInput({
     required this.pageNumber,
     required this.pageSize,
+    this.shouldRefresh = false,
   });
 }
 
 @lazySingleton
-class GetSurveysUseCase extends UseCase<List<Survey>, GetSurveysInput> {
+class GetSurveysUseCase extends StreamUseCase<List<Survey>, GetSurveysInput> {
   final SurveyRepository _surveyRepository;
 
   const GetSurveysUseCase(this._surveyRepository);
 
   @override
-  Future<Result<List<Survey>>> call(GetSurveysInput params) {
+  Stream<Result<List<Survey>>> call(GetSurveysInput params) {
     return _surveyRepository
-        .getSurveys(params.pageNumber, params.pageSize)
-        .then((value) =>
+        .getSurveys(
+          params.pageNumber,
+          params.pageSize,
+          params.shouldRefresh,
+        )
+        .map((value) =>
             Success(value) as Result<List<Survey>>) // ignore: unnecessary_cast
-        .onError<NetworkExceptions>(
-            (err, stackTrace) => Failed(UseCaseException(err)));
+        .onErrorReturnWith((err, stackTrace) => Failed(UseCaseException(err)));
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,8 @@ dependencies:
   page_view_indicators: ^2.0.0
   rxdart: ^0.27.7
   shimmer: ^2.0.0
+  hive: ^2.2.3
+  path_provider: ^2.0.15
 
 dev_dependencies:
   build_runner: ^2.1.11
@@ -61,6 +63,7 @@ dev_dependencies:
   mockito: ^5.2.0
   retrofit_generator: ^7.0.6
   injectable_generator: ^1.5.3
+  hive_generator: ^2.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/test/local/local_storage_test.dart
+++ b/test/local/local_storage_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_survey/local/local_storage.dart';
+import 'package:flutter_survey/model/survey.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 
@@ -8,10 +9,11 @@ void main() {
   group("LocalStorage", () {
     MockFlutterSecureStorage mockFlutterSecureStorage =
         MockFlutterSecureStorage();
+    MockBox mockSurveyBox = MockBox();
     late LocalStorage localStorage;
 
     setUp(() {
-      localStorage = LocalStorageImpl(mockFlutterSecureStorage);
+      localStorage = LocalStorageImpl(mockFlutterSecureStorage, mockSurveyBox);
     });
 
     test(
@@ -124,6 +126,48 @@ void main() {
         final isLoggedIn = await localStorage.isLoggedIn;
 
         expect(isLoggedIn, expectedValue);
+      },
+    );
+
+    test(
+      "When there are cached surveys, it returns the value accordingly",
+      () async {
+        final expectedValue = [];
+        when(mockSurveyBox.get(any, defaultValue: anyNamed("defaultValue")))
+            .thenAnswer((_) => expectedValue);
+
+        final cachedSurveys = await localStorage.surveys;
+
+        expect(cachedSurveys, expectedValue);
+      },
+    );
+
+    test(
+      "When caching surveys successfully, it calls the methods accordingly",
+      () async {
+        final surveys = [
+          const Survey(
+            id: "1",
+            title: "title",
+            description: "description",
+            coverImageUrl: "coverImageUrl",
+          )
+        ];
+        when(mockSurveyBox.get(any, defaultValue: anyNamed("defaultValue")))
+            .thenAnswer((_) => surveys);
+
+        await localStorage.cacheSurveys(surveys);
+
+        verify(mockSurveyBox.put(any, any)).called(1);
+      },
+    );
+
+    test(
+      "When clearing cached surveys, it calls the methods accordingly",
+      () async {
+        await localStorage.clearCachedSurveys();
+
+        verify(mockSurveyBox.delete(any)).called(1);
       },
     );
   });

--- a/test/mocks/generate_mocks.dart
+++ b/test/mocks/generate_mocks.dart
@@ -9,6 +9,7 @@ import 'package:flutter_survey/usecases/base/base_use_case.dart';
 import 'package:flutter_survey/usecases/get_surveys_use_case.dart';
 import 'package:flutter_survey/usecases/is_logged_in_use_case.dart';
 import 'package:flutter_survey/usecases/login_use_case.dart';
+import 'package:hive/hive.dart';
 import 'package:mockito/annotations.dart';
 
 @GenerateMocks([
@@ -17,6 +18,7 @@ import 'package:mockito/annotations.dart';
   SurveyService,
   LocalStorage,
   FlutterSecureStorage,
+  Box,
   AuthenticationRepository,
   SurveyRepository,
   IsLoggedInUseCase,

--- a/test/ui/home_view_model_test.dart
+++ b/test/ui/home_view_model_test.dart
@@ -46,8 +46,9 @@ void main() {
     setUp(() {
       mockGetSurveysUseCase = MockGetSurveysUseCase();
 
-      when(mockGetSurveysUseCase.call(any))
-          .thenAnswer((_) async => Success(surveys));
+      when(mockGetSurveysUseCase.call(any)).thenAnswer((_) async* {
+        yield Success(surveys);
+      });
 
       container = ProviderContainer(
         overrides: [
@@ -81,7 +82,9 @@ void main() {
       final surveysStream =
           container.read(homeViewModelProvider.notifier).surveysStream;
 
-      container.read(homeViewModelProvider.notifier).loadSurveys();
+      container
+          .read(homeViewModelProvider.notifier)
+          .loadSurveys(shouldLoadMore: true);
 
       expect(
         surveysStream,
@@ -117,8 +120,9 @@ void main() {
       'When loading surveys runs into an error, it emits values accordingly',
       () {
         const mockErrorMessage = "errorMessage";
-        when(mockGetSurveysUseCase.call(any)).thenAnswer(
-            (_) async => Failed(UseCaseException(Exception(mockErrorMessage))));
+        when(mockGetSurveysUseCase.call(any)).thenAnswer((_) async* {
+          yield Failed(UseCaseException(Exception(mockErrorMessage)));
+        });
         final stateStream =
             container.read(homeViewModelProvider.notifier).stream;
 

--- a/test/usecase/get_surveys_use_case_test.dart
+++ b/test/usecase/get_surveys_use_case_test.dart
@@ -20,32 +20,37 @@ void main() {
     test("When calling the use case successfully, it returns Success",
         () async {
       when(
-        mockMockSurveyRepository.getSurveys(1, 5),
-      ).thenAnswer((_) async => [
-            const Survey(
-                id: "1234",
-                title: "title",
-                description: "description",
-                coverImageUrl: "coverImageUrl")
-          ]);
+        mockMockSurveyRepository.getSurveys(1, 5, false),
+      ).thenAnswer((_) async* {
+        [
+          const Survey(
+              id: "1234",
+              title: "title",
+              description: "description",
+              coverImageUrl: "coverImageUrl")
+        ];
+      });
 
-      final result = await getSurveysUseCase
-          .call(GetSurveysInput(pageNumber: 1, pageSize: 5));
-
-      expect(result, isA<Success>());
+      getSurveysUseCase
+          .call(GetSurveysInput(pageNumber: 1, pageSize: 5))
+          .listen((result) {
+        expect(result, isA<Success>());
+      });
     });
 
     test("When calling the use case unsuccessfully, it returns Failed",
         () async {
       when(
-        mockMockSurveyRepository.getSurveys(1, 5),
-      ).thenAnswer((_) =>
-          Future.error(NetworkExceptions.fromDioException(MockDioException())));
+        mockMockSurveyRepository.getSurveys(1, 5, false),
+      ).thenAnswer((_) async* {
+        throw NetworkExceptions.fromDioException(MockDioException());
+      });
 
-      final result = await getSurveysUseCase
-          .call(GetSurveysInput(pageNumber: 1, pageSize: 5));
-
-      expect(result, isA<Failed>());
+      getSurveysUseCase
+          .call(GetSurveysInput(pageNumber: 1, pageSize: 5))
+          .listen((result) {
+        expect(result, isA<Failed>());
+      });
     });
   });
 }


### PR DESCRIPTION
https://github.com/nimblehq/ic-flutter-avishek/issues/49
https://github.com/nimblehq/ic-flutter-avishek/issues/50

## What happened 👀

- Cache the surveys on the device, after fetching them successfully from the API
- Display surveys from cache, after the user relaunches the app
- Display surveys from API, if there's any difference with the cached data
- Add unit tests

## Insight 📝

Added a new base Use Case that returns `Stream` instead of `Future` to facilitate multiple emissions from the same repository method and updated the code accordingly.

## Proof Of Work 📹

https://github.com/nimblehq/ic-flutter-avishek/assets/8093908/5cc1fcf2-86a6-4eb0-91f2-ca12e06c0d8a


