### PR TITLE
[15] [Backend] Get survey details

### DIFF
--- a/lib/api/repository/survey_repository.dart
+++ b/lib/api/repository/survey_repository.dart
@@ -4,6 +4,7 @@ import 'package:injectable/injectable.dart';
 
 import '../../local/local_storage.dart';
 import '../../model/survey.dart';
+import '../../model/survey_detail.dart';
 import '../exception/network_exceptions.dart';
 import '../survey_service.dart';
 
@@ -13,6 +14,8 @@ abstract class SurveyRepository {
     int pageSize,
     bool shouldRefresh,
   );
+
+  Future<SurveyDetail> getSurveyDetail(String surveyId);
 }
 
 @LazySingleton(as: SurveyRepository)
@@ -74,5 +77,15 @@ class SurveyRepositoryImpl extends SurveyRepository {
       _localStorage.clearCachedSurveys();
     }
     _localStorage.cacheSurveys(surveys);
+  }
+
+  @override
+  Future<SurveyDetail> getSurveyDetail(String surveyId) async {
+    try {
+      final response = await _surveyService.getSurveyDetail(surveyId);
+      return SurveyDetail.fromSurveyDetailResponse(response);
+    } catch (exception) {
+      throw NetworkExceptions.fromDioException(exception);
+    }
   }
 }

--- a/lib/api/survey_service.dart
+++ b/lib/api/survey_service.dart
@@ -27,7 +27,7 @@ abstract class SurveyService extends BaseSurveyService {
   );
 
   @override
-  @GET('/v1/surveys/{surveyId}')
+  @GET('api/v1/surveys/{surveyId}')
   Future<SurveyDetailResponse> getSurveyDetail(
     @Path('surveyId') String surveyId,
   );

--- a/lib/api/survey_service.dart
+++ b/lib/api/survey_service.dart
@@ -1,15 +1,18 @@
 import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';
 
+import '../model/response/survey_detail_response.dart';
 import '../model/response/survey_list_response.dart';
 
 part 'survey_service.g.dart';
 
 abstract class BaseSurveyService {
   Future<SurveyListResponse> getSurveys(
-    @Path('pageNumber') int pageNumber,
-    @Path('pageSize') int pageSize,
+    int pageNumber,
+    int pageSize,
   );
+
+  Future<SurveyDetailResponse> getSurveyDetail(String surveyId);
 }
 
 @RestApi()
@@ -21,5 +24,11 @@ abstract class SurveyService extends BaseSurveyService {
   Future<SurveyListResponse> getSurveys(
     @Path('pageNumber') int pageNumber,
     @Path('pageSize') int pageSize,
+  );
+
+  @override
+  @GET('/v1/surveys/{surveyId}')
+  Future<SurveyDetailResponse> getSurveyDetail(
+    @Path('surveyId') String surveyId,
   );
 }

--- a/lib/model/question.dart
+++ b/lib/model/question.dart
@@ -1,0 +1,61 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter_survey/model/response/question_response.dart';
+
+class Question extends Equatable {
+  final String id;
+  final String text;
+  final int displayOrder;
+  final DisplayType displayType;
+  final String imageUrl;
+  final String coverImageUrl;
+  final double coverImageOpacity;
+
+  const Question({
+    required this.id,
+    required this.text,
+    required this.displayOrder,
+    required this.displayType,
+    required this.imageUrl,
+    required this.coverImageOpacity,
+    required this.coverImageUrl,
+  });
+
+  @override
+  List<Object?> get props => [
+        id,
+        text,
+        displayOrder,
+        displayType,
+        imageUrl,
+        coverImageOpacity,
+        coverImageUrl,
+      ];
+
+  factory Question.fromQuestionResponse(QuestionResponse response) {
+    return Question(
+      id: response.id,
+      text: response.text ?? '',
+      displayOrder: response.displayOrder ?? 0,
+      displayType: response.displayType ?? DisplayType.unknown,
+      imageUrl: response.imageUrl ?? "",
+      coverImageOpacity: response.coverImageOpacity ?? 0,
+      coverImageUrl: response.coverImageUrl ?? "",
+    );
+  }
+}
+
+enum DisplayType {
+  star,
+  heart,
+  smiley,
+  choice,
+  nps,
+  textarea,
+  textfield,
+  dropdown,
+  money,
+  slider,
+  intro,
+  outro,
+  unknown,
+}

--- a/lib/model/response/answer_response.dart
+++ b/lib/model/response/answer_response.dart
@@ -1,0 +1,23 @@
+import 'package:json_annotation/json_annotation.dart';
+
+import '../../api/response_converter.dart';
+
+part 'answer_response.g.dart';
+
+@JsonSerializable()
+class AnswerResponse {
+  final String id;
+  final String? text;
+  final int displayOrder;
+  final String displayType;
+
+  AnswerResponse({
+    required this.id,
+    required this.text,
+    required this.displayOrder,
+    required this.displayType,
+  });
+
+  factory AnswerResponse.fromJson(Map<String, dynamic> json) =>
+      _$AnswerResponseFromJson(fromJsonApi(json));
+}

--- a/lib/model/response/question_response.dart
+++ b/lib/model/response/question_response.dart
@@ -1,0 +1,33 @@
+import 'package:json_annotation/json_annotation.dart';
+
+import '../../api/response_converter.dart';
+import '../question.dart';
+import 'answer_response.dart';
+
+part 'question_response.g.dart';
+
+@JsonSerializable()
+class QuestionResponse {
+  final String id;
+  final String? text;
+  final int? displayOrder;
+  final DisplayType? displayType;
+  final String? imageUrl;
+  final String? coverImageUrl;
+  final double? coverImageOpacity;
+  final List<AnswerResponse> answers;
+
+  QuestionResponse({
+    required this.id,
+    required this.text,
+    required this.displayOrder,
+    required this.displayType,
+    required this.imageUrl,
+    required this.coverImageUrl,
+    required this.coverImageOpacity,
+    required this.answers,
+  });
+
+  factory QuestionResponse.fromJson(Map<String, dynamic> json) =>
+      _$QuestionResponseFromJson(fromJsonApi(json));
+}

--- a/lib/model/response/survey_detail_response.dart
+++ b/lib/model/response/survey_detail_response.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_survey/model/response/question_response.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+import '../../api/response_converter.dart';
+
+part 'survey_detail_response.g.dart';
+
+@JsonSerializable()
+class SurveyDetailResponse {
+  final String id;
+  final List<QuestionResponse> questions;
+
+  SurveyDetailResponse({
+    required this.id,
+    required this.questions,
+  });
+
+  factory SurveyDetailResponse.fromJson(Map<String, dynamic> json) =>
+      _$SurveyDetailResponseFromJson(fromJsonApi(json));
+}

--- a/lib/model/survey_detail.dart
+++ b/lib/model/survey_detail.dart
@@ -1,0 +1,22 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter_survey/model/question.dart';
+import 'package:flutter_survey/model/response/survey_detail_response.dart';
+
+class SurveyDetail extends Equatable {
+  final List<Question> questions;
+
+  const SurveyDetail({
+    required this.questions,
+  });
+
+  @override
+  List<Object?> get props => [questions];
+
+  factory SurveyDetail.fromSurveyDetailResponse(SurveyDetailResponse response) {
+    return SurveyDetail(
+      questions: response.questions
+          .map((e) => Question.fromQuestionResponse(e))
+          .toList(),
+    );
+  }
+}

--- a/lib/ui/home/home_screen.dart
+++ b/lib/ui/home/home_screen.dart
@@ -56,9 +56,7 @@ class HomeScreenState extends ConsumerState<HomeScreen> {
   Widget build(BuildContext context) {
     final uiModels = ref.watch(_surveysStreamProvider).value ?? [];
     return ref.watch(homeViewModelProvider).when(
-          init: () => const Center(
-            child: SkeletonLoadingScreen(),
-          ),
+          init: () => const SkeletonLoadingScreen(),
           loading: () => _buildHomeScreen(uiModels, true),
           success: () => _buildHomeScreen(uiModels, false),
           error: (message) {

--- a/lib/usecases/get_survey_detail_use_case.dart
+++ b/lib/usecases/get_survey_detail_use_case.dart
@@ -13,7 +13,7 @@ class GetSurveyDetailInput {
   });
 }
 
-@Injectable()
+@lazySingleton
 class GetSurveyDetailUseCase
     extends UseCase<SurveyDetail, GetSurveyDetailInput> {
   final SurveyRepository _surveyRepository;

--- a/lib/usecases/get_survey_detail_use_case.dart
+++ b/lib/usecases/get_survey_detail_use_case.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_survey/api/exception/network_exceptions.dart';
+import 'package:flutter_survey/api/repository/survey_repository.dart';
+import 'package:injectable/injectable.dart';
+
+import '../model/survey_detail.dart';
+import 'base/base_use_case.dart';
+
+class GetSurveyDetailInput {
+  String surveyId;
+
+  GetSurveyDetailInput({
+    required this.surveyId,
+  });
+}
+
+@Injectable()
+class GetSurveyDetailUseCase
+    extends UseCase<SurveyDetail, GetSurveyDetailInput> {
+  final SurveyRepository _surveyRepository;
+
+  const GetSurveyDetailUseCase(this._surveyRepository);
+
+  @override
+  Future<Result<SurveyDetail>> call(GetSurveyDetailInput params) {
+    return _surveyRepository
+        .getSurveyDetail(params.surveyId)
+        .then((value) =>
+            Success(value) as Result<SurveyDetail>) // ignore: unnecessary_cast
+        .onError<NetworkExceptions>(
+            (err, stackTrace) => Failed(UseCaseException(err)));
+  }
+}

--- a/test/api/repository/survey_repository_test.dart
+++ b/test/api/repository/survey_repository_test.dart
@@ -1,6 +1,10 @@
 import 'package:flutter_config/flutter_config.dart';
 import 'package:flutter_survey/api/exception/network_exceptions.dart';
 import 'package:flutter_survey/api/repository/survey_repository.dart';
+import 'package:flutter_survey/model/question.dart';
+import 'package:flutter_survey/model/response/answer_response.dart';
+import 'package:flutter_survey/model/response/question_response.dart';
+import 'package:flutter_survey/model/response/survey_detail_response.dart';
 import 'package:flutter_survey/model/response/survey_list_response.dart';
 import 'package:flutter_survey/model/response/survey_response.dart';
 import 'package:flutter_survey/model/survey.dart';
@@ -19,6 +23,23 @@ void main() {
       SurveyListResponse(data: [SurveyResponse(id: "1234")]);
   final surveys =
       surveyResponses.data.map((e) => Survey.fromSurveyResponse(e)).toList();
+  final surveyDetailResponse = SurveyDetailResponse(id: "1", questions: [
+    QuestionResponse(
+        id: "1",
+        text: "text",
+        displayOrder: 1,
+        displayType: DisplayType.intro,
+        imageUrl: "imageUrl",
+        coverImageUrl: "coverImageUrl",
+        coverImageOpacity: 50.0,
+        answers: [
+          AnswerResponse(
+              id: "1",
+              text: "text",
+              displayOrder: 1,
+              displayType: DisplayType.intro.name),
+        ])
+  ]);
 
   group("SurveyRepository", () {
     MockSurveyService mockSurveyService = MockSurveyService();
@@ -90,6 +111,27 @@ void main() {
       surveyRepository.getSurveys(1, 5, false).listen((result) {
         expect(result, isA<NetworkExceptions>());
       });
+    });
+
+    test(
+        'When fetching survey details successfully, it returns corresponding response',
+        () async {
+      when(mockSurveyService.getSurveyDetail(any))
+          .thenAnswer((_) async => surveyDetailResponse);
+      final result = await surveyRepository.getSurveyDetail("1");
+
+      expect(result.questions.length, 1);
+      expect(result.questions[0].text, "text");
+    });
+
+    test(
+        'When calling getSurveyDetail failed, it returns NetworkExceptions error',
+        () async {
+      when(mockSurveyService.getSurveyDetail(any))
+          .thenThrow(MockDioException());
+      result() => surveyRepository.getSurveyDetail("1");
+
+      expect(result, throwsA(isA<NetworkExceptions>()));
     });
   });
 }

--- a/test/mocks/generate_mocks.dart
+++ b/test/mocks/generate_mocks.dart
@@ -5,6 +5,7 @@ import 'package:flutter_survey/api/repository/authentication_repository.dart';
 import 'package:flutter_survey/api/repository/survey_repository.dart';
 import 'package:flutter_survey/api/survey_service.dart';
 import 'package:flutter_survey/local/local_storage.dart';
+import 'package:flutter_survey/model/survey_detail.dart';
 import 'package:flutter_survey/usecases/base/base_use_case.dart';
 import 'package:flutter_survey/usecases/get_surveys_use_case.dart';
 import 'package:flutter_survey/usecases/is_logged_in_use_case.dart';
@@ -24,7 +25,8 @@ import 'package:mockito/annotations.dart';
   IsLoggedInUseCase,
   LoginUseCase,
   GetSurveysUseCase,
-  UseCaseException
+  UseCaseException,
+  SurveyDetail,
 ])
 main() {
   // empty class to generate mock repository classes

--- a/test/usecase/get_survey_detail_use_case_test.dart
+++ b/test/usecase/get_survey_detail_use_case_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_survey/api/exception/network_exceptions.dart';
+import 'package:flutter_survey/usecases/base/base_use_case.dart';
+import 'package:flutter_survey/usecases/get_survey_detail_use_case.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import '../mocks/generate_mocks.mocks.dart';
+
+void main() {
+  group('GetSurveyDetailUseCaseTest', () {
+    late MockSurveyRepository mockRepository;
+    late GetSurveyDetailUseCase getSurveyDetailUseCase;
+
+    setUp(() async {
+      mockRepository = MockSurveyRepository();
+      getSurveyDetailUseCase = GetSurveyDetailUseCase(mockRepository);
+    });
+
+    test('When calling the use case successfully, it returns Success',
+        () async {
+      final survey = MockSurveyDetail();
+
+      when(mockRepository.getSurveyDetail(any)).thenAnswer((_) async => survey);
+      final result = await getSurveyDetailUseCase.call(GetSurveyDetailInput(
+        surveyId: "1",
+      ));
+
+      expect(result, isA<Success>());
+    });
+
+    test('When calling the use case unsuccessfully, it returns Failed',
+        () async {
+      when(mockRepository.getSurveyDetail(any)).thenAnswer((_) => Future.error(
+            const NetworkExceptions.unauthorisedRequest(),
+          ));
+      final result = await getSurveyDetailUseCase.call(GetSurveyDetailInput(
+        surveyId: "1",
+      ));
+
+      expect(result, isA<Failed>());
+      expect((result as Failed).exception.actualException,
+          const NetworkExceptions.unauthorisedRequest());
+    });
+  });
+}


### PR DESCRIPTION
https://github.com/nimblehq/ic-flutter-avishek/issues/15

## What happened 👀

- Call the endpoint `/api/v1/surveys/<survey_id>`.
- Show error if the API returns an error.
- Parse the JSON response to an object if it returns success.

## Insight 📝

PoW is created from calling the use case from VM after fetching the surveys and using the first survey ID.

## Proof Of Work 📹

<img width="1364" alt="image" src="https://github.com/nimblehq/ic-flutter-avishek/assets/8093908/43e323b6-e8c2-4584-9f12-383de283f5a2">
