### PR TITLE
[53] [Integrate] Survey details screen

### DIFF
--- a/lib/model/response/question_response.dart
+++ b/lib/model/response/question_response.dart
@@ -15,7 +15,7 @@ class QuestionResponse {
   final String? imageUrl;
   final String? coverImageUrl;
   final double? coverImageOpacity;
-  final List<AnswerResponse> answers;
+  final List<AnswerResponse>? answers;
 
   QuestionResponse({
     required this.id,

--- a/lib/ui/home/survey_ui_model.dart
+++ b/lib/ui/home/survey_ui_model.dart
@@ -1,11 +1,15 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_survey/model/survey.dart';
 
+import '../../model/question.dart';
+import '../../model/survey_detail.dart';
+
 class SurveyUiModel extends Equatable {
   final String id;
   final String title;
   final String description;
   final String coverImageUrl;
+  final List<Question> questions;
 
   String get largeCoverImageUrl => "${coverImageUrl}l";
 
@@ -14,6 +18,7 @@ class SurveyUiModel extends Equatable {
     required this.title,
     required this.description,
     required this.coverImageUrl,
+    required this.questions,
   });
 
   factory SurveyUiModel.fromSurvey(Survey survey) {
@@ -22,9 +27,23 @@ class SurveyUiModel extends Equatable {
       title: survey.title,
       description: survey.description,
       coverImageUrl: survey.coverImageUrl,
+      questions: const [],
+    );
+  }
+
+  factory SurveyUiModel.fromSurveyDetail(
+    SurveyUiModel survey,
+    SurveyDetail surveyDetail,
+  ) {
+    return SurveyUiModel(
+      id: survey.id,
+      title: survey.title,
+      description: survey.description,
+      coverImageUrl: survey.coverImageUrl,
+      questions: surveyDetail.questions,
     );
   }
 
   @override
-  List<Object?> get props => [id, title, description, coverImageUrl];
+  List<Object?> get props => [id, title, description, coverImageUrl, questions];
 }

--- a/lib/ui/surveydetail/survey_detail_screen.dart
+++ b/lib/ui/surveydetail/survey_detail_screen.dart
@@ -69,34 +69,28 @@ class SurveyDetailScreenState extends ConsumerState<SurveyDetailScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return WillPopScope(
-      onWillPop: () async {
-        _zoomOutAndPop();
-        return false;
-      },
-      child: Scaffold(
-        resizeToAvoidBottomInset: false,
-        body: ref.watch(surveyDetailViewModelProvider).when(
-              init: () => const SizedBox.shrink(),
-              loading: () => _buildSurveyScreen(widget.surveyUiModel, true),
-              success: () => _buildSurveyScreen(widget.surveyUiModel, false),
-              error: (message) {
-                WidgetsBinding.instance.addPostFrameCallback((_) {
-                  ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-                      content: Text(message ??
-                          AppLocalizations.of(context)!.errorGeneric)));
-                });
-                return _buildSurveyScreen(widget.surveyUiModel, false);
-              },
-            ),
-      ),
+    return Scaffold(
+      resizeToAvoidBottomInset: false,
+      body: ref.watch(surveyDetailViewModelProvider).when(
+            init: () => const SizedBox.shrink(),
+            loading: () => _buildSurveyScreen(widget.surveyUiModel, true),
+            success: () => _buildSurveyScreen(widget.surveyUiModel, false),
+            error: (message) {
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                    content: Text(message ??
+                        AppLocalizations.of(context)!.errorGeneric)));
+              });
+              return _buildSurveyScreen(widget.surveyUiModel, false);
+            },
+          ),
     );
   }
 
   Widget _buildSurveyScreen(SurveyUiModel? survey, bool isLoading) {
     Future.delayed(Duration.zero, () {
       final shouldZoomInBackground =
-      ref.watch(shouldZoomInBackgroundProvider.notifier);
+          ref.watch(shouldZoomInBackgroundProvider.notifier);
       shouldZoomInBackground.state = true;
     });
     return survey != null
@@ -133,7 +127,7 @@ class SurveyDetailScreenState extends ConsumerState<SurveyDetailScreen> {
     pages.add(
       SurveyIntro(
         survey: survey,
-        onNext: () => _gotoNextPage(),
+        onNext: _gotoNextPage,
         onClose: _zoomOutAndPop,
       ),
     );

--- a/lib/ui/surveydetail/survey_detail_screen.dart
+++ b/lib/ui/surveydetail/survey_detail_screen.dart
@@ -1,18 +1,32 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_survey/ui/surveydetail/survey_detail_state.dart';
+import 'package:flutter_survey/ui/surveydetail/survey_detail_view_model.dart';
 import 'package:flutter_survey/ui/surveydetail/survey_intro.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../di/di.dart';
+import '../../usecases/get_survey_detail_use_case.dart';
 import '../home/survey_ui_model.dart';
 import '../widget/dimmed_image_background.dart';
+import '../widget/loading_indicator.dart';
 
 const Duration _pageScrollDuration = Duration(milliseconds: 200);
 const double _initialBackgroundScale = 1;
 const double _finalBackgroundScale = 1.5;
 const _imageScaleAnimationDurationInMillis = 700;
 
-final shouldAnimateBackgroundScaleProvider =
+final shouldZoomInBackgroundProvider =
     StateProvider.autoDispose<bool>((_) => false);
+
+final surveyDetailViewModelProvider =
+    StateNotifierProvider.autoDispose<SurveyDetailViewModel, SurveyDetailState>(
+        (ref) {
+  return SurveyDetailViewModel(
+    getIt.get<GetSurveyDetailUseCase>(),
+  );
+});
 
 class SurveyDetailScreenKey {
   SurveyDetailScreenKey._();
@@ -39,11 +53,12 @@ class SurveyDetailScreenState extends ConsumerState<SurveyDetailScreen> {
   @override
   void initState() {
     super.initState();
-    Future.delayed(Duration.zero, () {
-      final shouldAnimateBackgroundScale =
-          ref.watch(shouldAnimateBackgroundScaleProvider.notifier);
-      shouldAnimateBackgroundScale.state = !shouldAnimateBackgroundScale.state;
-    });
+    final surveyUiModel = widget.surveyUiModel;
+    if (surveyUiModel != null) {
+      ref
+          .read(surveyDetailViewModelProvider.notifier)
+          .loadSurveyDetail(surveyUiModel);
+    }
   }
 
   @override
@@ -56,28 +71,45 @@ class SurveyDetailScreenState extends ConsumerState<SurveyDetailScreen> {
   Widget build(BuildContext context) {
     return WillPopScope(
       onWillPop: () async {
-        _animateScaleAndPop();
+        _zoomOutAndPop();
         return false;
       },
       child: Scaffold(
         resizeToAvoidBottomInset: false,
-        body: _buildSurveyScreen(widget.surveyUiModel),
+        body: ref.watch(surveyDetailViewModelProvider).when(
+              init: () => const SizedBox.shrink(),
+              loading: () => _buildSurveyScreen(widget.surveyUiModel, true),
+              success: () => _buildSurveyScreen(widget.surveyUiModel, false),
+              error: (message) {
+                WidgetsBinding.instance.addPostFrameCallback((_) {
+                  ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                      content: Text(message ??
+                          AppLocalizations.of(context)!.errorGeneric)));
+                });
+                return _buildSurveyScreen(widget.surveyUiModel, false);
+              },
+            ),
       ),
     );
   }
 
-  Widget _buildSurveyScreen(SurveyUiModel? survey) {
+  Widget _buildSurveyScreen(SurveyUiModel? survey, bool isLoading) {
+    Future.delayed(Duration.zero, () {
+      final shouldZoomInBackground =
+      ref.watch(shouldZoomInBackgroundProvider.notifier);
+      shouldZoomInBackground.state = true;
+    });
     return survey != null
         ? Stack(
             children: [
               Consumer(builder: (_, ref, __) {
-                final shouldAnimateBackgroundScale =
-                    ref.watch(shouldAnimateBackgroundScaleProvider);
+                final shouldZoomInBackground =
+                    ref.watch(shouldZoomInBackgroundProvider);
                 return AnimatedScale(
                   duration: const Duration(
                     milliseconds: _imageScaleAnimationDurationInMillis,
                   ),
-                  scale: shouldAnimateBackgroundScale
+                  scale: shouldZoomInBackground
                       ? _finalBackgroundScale
                       : _initialBackgroundScale,
                   child: DimmedImageBackground(
@@ -86,6 +118,11 @@ class SurveyDetailScreenState extends ConsumerState<SurveyDetailScreen> {
                 );
               }),
               SafeArea(child: _buildSurveyQuestionPager(survey)),
+              Center(
+                child: isLoading
+                    ? const LoadingIndicator()
+                    : const SizedBox.shrink(),
+              )
             ],
           )
         : const SizedBox.shrink();
@@ -97,7 +134,7 @@ class SurveyDetailScreenState extends ConsumerState<SurveyDetailScreen> {
       SurveyIntro(
         survey: survey,
         onNext: () => _gotoNextPage(),
-        onClose: _animateScaleAndPop,
+        onClose: _zoomOutAndPop,
       ),
     );
 
@@ -116,10 +153,10 @@ class SurveyDetailScreenState extends ConsumerState<SurveyDetailScreen> {
     );
   }
 
-  void _animateScaleAndPop() {
-    final shouldAnimateBackgroundScale =
-        ref.watch(shouldAnimateBackgroundScaleProvider.notifier);
-    shouldAnimateBackgroundScale.state = !shouldAnimateBackgroundScale.state;
+  void _zoomOutAndPop() {
+    final shouldZoomInBackground =
+        ref.watch(shouldZoomInBackgroundProvider.notifier);
+    shouldZoomInBackground.state = false;
     Future.delayed(
       const Duration(milliseconds: _imageScaleAnimationDurationInMillis),
       context.pop,

--- a/lib/ui/surveydetail/survey_detail_screen.dart
+++ b/lib/ui/surveydetail/survey_detail_screen.dart
@@ -28,6 +28,9 @@ final surveyDetailViewModelProvider =
   );
 });
 
+final _surveyStreamProvider = StreamProvider.autoDispose<SurveyUiModel>(
+    (ref) => ref.watch(surveyDetailViewModelProvider.notifier).surveyStream);
+
 class SurveyDetailScreenKey {
   SurveyDetailScreenKey._();
 
@@ -69,19 +72,20 @@ class SurveyDetailScreenState extends ConsumerState<SurveyDetailScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final uiModel = ref.watch(_surveyStreamProvider).value;
     return Scaffold(
       resizeToAvoidBottomInset: false,
       body: ref.watch(surveyDetailViewModelProvider).when(
             init: () => const SizedBox.shrink(),
-            loading: () => _buildSurveyScreen(widget.surveyUiModel, true),
-            success: () => _buildSurveyScreen(widget.surveyUiModel, false),
+            loading: () => _buildSurveyScreen(uiModel, true),
+            success: () => _buildSurveyScreen(uiModel, false),
             error: (message) {
               WidgetsBinding.instance.addPostFrameCallback((_) {
                 ScaffoldMessenger.of(context).showSnackBar(SnackBar(
                     content: Text(message ??
                         AppLocalizations.of(context)!.errorGeneric)));
               });
-              return _buildSurveyScreen(widget.surveyUiModel, false);
+              return _buildSurveyScreen(uiModel, false);
             },
           ),
     );

--- a/lib/ui/surveydetail/survey_detail_state.dart
+++ b/lib/ui/surveydetail/survey_detail_state.dart
@@ -1,0 +1,14 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'survey_detail_state.freezed.dart';
+
+@freezed
+class SurveyDetailState with _$SurveyDetailState {
+  const factory SurveyDetailState.init() = _Init;
+
+  const factory SurveyDetailState.loading() = _Loading;
+
+  const factory SurveyDetailState.error(String? error) = _Error;
+
+  const factory SurveyDetailState.success() = _Success;
+}

--- a/lib/ui/surveydetail/survey_detail_view_model.dart
+++ b/lib/ui/surveydetail/survey_detail_view_model.dart
@@ -28,7 +28,8 @@ class SurveyDetailViewModel extends StateNotifier<SurveyDetailState> {
     ));
     if (result is Success<SurveyDetail>) {
       final surveyDetail = result.value;
-      _surveySubject.add(SurveyUiModel.fromSurveyDetail(surveyUiModel, surveyDetail));
+      _surveySubject
+          .add(SurveyUiModel.fromSurveyDetail(surveyUiModel, surveyDetail));
       state = const SurveyDetailState.success();
     } else {
       _handleError(result as Failed);

--- a/lib/ui/surveydetail/survey_detail_view_model.dart
+++ b/lib/ui/surveydetail/survey_detail_view_model.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_survey/ui/surveydetail/survey_detail_state.dart';
+import 'package:rxdart/subjects.dart';
+
+import '../../model/survey_detail.dart';
+import '../../usecases/base/base_use_case.dart';
+import '../../usecases/get_survey_detail_use_case.dart';
+import '../home/survey_ui_model.dart';
+
+class SurveyDetailViewModel extends StateNotifier<SurveyDetailState> {
+  final GetSurveyDetailUseCase _getSurveyDetailUseCase;
+
+  SurveyDetailViewModel(
+    this._getSurveyDetailUseCase,
+  ) : super(const SurveyDetailState.init());
+
+  final BehaviorSubject<SurveyUiModel> _surveySubject = BehaviorSubject();
+
+  Stream<SurveyUiModel> get surveyStream => _surveySubject.stream;
+
+  Future<void> loadSurveyDetail(SurveyUiModel surveyUiModel) async {
+    _surveySubject.add(surveyUiModel);
+    state = const SurveyDetailState.success();
+
+    state = const SurveyDetailState.loading();
+    final result = await _getSurveyDetailUseCase.call(GetSurveyDetailInput(
+      surveyId: surveyUiModel.id,
+    ));
+    if (result is Success<SurveyDetail>) {
+      final surveyDetail = result.value;
+      _surveySubject.add(SurveyUiModel.fromSurveyDetail(surveyUiModel, surveyDetail));
+      state = const SurveyDetailState.success();
+    } else {
+      _handleError(result as Failed);
+    }
+  }
+
+  _handleError(Failed result) {
+    state = SurveyDetailState.error(result.getErrorMessage());
+  }
+
+  @override
+  void dispose() async {
+    await _surveySubject.close();
+    super.dispose();
+  }
+}

--- a/test/mocks/generate_mocks.dart
+++ b/test/mocks/generate_mocks.dart
@@ -7,6 +7,7 @@ import 'package:flutter_survey/api/survey_service.dart';
 import 'package:flutter_survey/local/local_storage.dart';
 import 'package:flutter_survey/model/survey_detail.dart';
 import 'package:flutter_survey/usecases/base/base_use_case.dart';
+import 'package:flutter_survey/usecases/get_survey_detail_use_case.dart';
 import 'package:flutter_survey/usecases/get_surveys_use_case.dart';
 import 'package:flutter_survey/usecases/is_logged_in_use_case.dart';
 import 'package:flutter_survey/usecases/login_use_case.dart';
@@ -25,6 +26,7 @@ import 'package:mockito/annotations.dart';
   IsLoggedInUseCase,
   LoginUseCase,
   GetSurveysUseCase,
+  GetSurveyDetailUseCase,
   UseCaseException,
   SurveyDetail,
 ])

--- a/test/ui/survey_detail_view_model_test.dart
+++ b/test/ui/survey_detail_view_model_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_survey/api/exception/network_exceptions.dart';
+import 'package:flutter_survey/model/survey_detail.dart';
+import 'package:flutter_survey/ui/home/survey_ui_model.dart';
+import 'package:flutter_survey/ui/surveydetail/survey_detail_screen.dart';
+import 'package:flutter_survey/ui/surveydetail/survey_detail_state.dart';
+import 'package:flutter_survey/ui/surveydetail/survey_detail_view_model.dart';
+import 'package:flutter_survey/usecases/base/base_use_case.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import '../mocks/generate_mocks.mocks.dart';
+
+void main() {
+  group('SurveyDetailViewModelTest', () {
+    late MockGetSurveyDetailUseCase mockGetSurveyDetailUseCase;
+    late ProviderContainer container;
+
+    late SurveyDetail surveyDetail = const SurveyDetail(questions: []);
+    late SurveyUiModel surveyUiModel = const SurveyUiModel(
+      id: "1",
+      title: "title",
+      description: "description",
+      coverImageUrl: "coverImageUrl",
+      questions: [],
+    );
+
+    setUp(() async {
+      mockGetSurveyDetailUseCase = MockGetSurveyDetailUseCase();
+      container = ProviderContainer(
+        overrides: [
+          surveyDetailViewModelProvider.overrideWithValue(SurveyDetailViewModel(
+            mockGetSurveyDetailUseCase,
+          )),
+        ],
+      );
+
+      when(mockGetSurveyDetailUseCase.call(any))
+          .thenAnswer((_) async => Success(surveyDetail));
+
+      addTearDown(container.dispose);
+    });
+
+    test('When initializing, it initializes with the Init state', () {
+      expect(container.read(surveyDetailViewModelProvider),
+          const SurveyDetailState.init());
+    });
+
+    test('When fetching Survey details, it emits accordingly', () async {
+      final stateStream =
+          container.read(surveyDetailViewModelProvider.notifier).stream;
+      final surveyStream =
+          container.read(surveyDetailViewModelProvider.notifier).surveyStream;
+
+      expect(
+          stateStream,
+          emitsInOrder([
+            const SurveyDetailState.success(),
+            const SurveyDetailState.loading(),
+            const SurveyDetailState.success(),
+          ]));
+      expect(
+          surveyStream,
+          emitsInOrder([
+            surveyUiModel,
+            SurveyUiModel.fromSurveyDetail(
+              surveyUiModel,
+              surveyDetail,
+            ),
+          ]));
+
+      container
+          .read(surveyDetailViewModelProvider.notifier)
+          .loadSurveyDetail(surveyUiModel);
+    });
+
+    test(
+        'When fetching survey details unsuccessfully, it emits Failed state accordingly',
+        () {
+      final mockException = MockUseCaseException();
+      when(mockException.actualException)
+          .thenReturn(const NetworkExceptions.internalServerError());
+      when(mockGetSurveyDetailUseCase.call(any))
+          .thenAnswer((_) async => Failed(mockException));
+      final stateStream =
+          container.read(surveyDetailViewModelProvider.notifier).stream;
+      final surveyStream =
+          container.read(surveyDetailViewModelProvider.notifier).surveyStream;
+
+      expect(
+          stateStream,
+          emitsInOrder([
+            const SurveyDetailState.success(),
+            const SurveyDetailState.loading(),
+            SurveyDetailState.error(
+              NetworkExceptions.getErrorMessage(
+                  const NetworkExceptions.internalServerError()),
+            )
+          ]));
+      expect(
+          surveyStream,
+          emitsInOrder([
+            surveyUiModel,
+          ]));
+
+      container
+          .read(surveyDetailViewModelProvider.notifier)
+          .loadSurveyDetail(surveyUiModel);
+    });
+  });
+}


### PR DESCRIPTION
https://github.com/nimblehq/ic-flutter-avishek/issues/53

## What happened 👀

- Show `cover_image_url`  as the survey background (with gradient).
- Show `title` as the survey title.
- Show `description` as the survey description.
- Show an error message with the snack-bar, if the request failed.

## Insight 📝

For some reason, the zoom-out animation doesn't work as intended when pressing the navigation bar back button. Any insight on this would be much appreciated. 🙏🏽 

## Proof Of Work 📹

### Android

https://github.com/nimblehq/ic-flutter-avishek/assets/8093908/6ac10dde-9493-4ea6-88e8-c5c0ef094c89

### iOS

https://github.com/nimblehq/ic-flutter-avishek/assets/8093908/d3c8cf34-ab7a-4007-b4ff-b3d4ee69b82b



